### PR TITLE
fix: incorrect typings for `getAllControllerData`

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -148,7 +148,7 @@ module.exports = class Client extends EventEmitter {
 	}
 	/**
 	 * get the properties of all devices
-	 * @returns {Promise<Device>[]}
+	 * @returns {Promise<Promise<Device>[]>}
 	 */
 	async getAllControllerData () {
 		let devices = []

--- a/src/client.js
+++ b/src/client.js
@@ -148,7 +148,7 @@ module.exports = class Client extends EventEmitter {
 	}
 	/**
 	 * get the properties of all devices
-	 * @returns {Promise<Promise<Device>[]>}
+	 * @returns {Promise<Device[]>}
 	 */
 	async getAllControllerData () {
 		let devices = []
@@ -160,7 +160,7 @@ module.exports = class Client extends EventEmitter {
 	}
 	/**
 	 * get a list of all profiles
-	 * @returns {Promise<String>[]}
+	 * @returns {Promise<String[]>}
 	 */
 	async getProfileList () {
 		this.sendMessage(utils.command.requestProfileList)

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -42,7 +42,7 @@ declare class Client {
     getControllerData(deviceId: number): Promise<Device>;
     /**
      * get the properties of all devices
-     * @returns {Promise<Device>[]}
+     * @returns {Promise<Promise<Device>[]>}
      */
     getAllControllerData(): Promise<Promise<Device>[]>;
     /**

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -42,14 +42,14 @@ declare class Client {
     getControllerData(deviceId: number): Promise<Device>;
     /**
      * get the properties of all devices
-     * @returns {Promise<Promise<Device>[]>}
+     * @returns {Promise<Device[]>}
      */
-    getAllControllerData(): Promise<Promise<Device>[]>;
+    getAllControllerData(): Promise<Device[]>;
     /**
      * get a list of all profiles
-     * @returns {Promise<String>[]}
+     * @returns {Promise<String[]>}
      */
-    getProfileList(): Promise<string>[];
+    getProfileList(): Promise<string[]>;
     /**
      * set the name of the client
      * @param {string} name the name displayed in openrgb

--- a/types/client.d.ts
+++ b/types/client.d.ts
@@ -44,7 +44,7 @@ declare class Client {
      * get the properties of all devices
      * @returns {Promise<Device>[]}
      */
-    getAllControllerData(): Promise<Device>[];
+    getAllControllerData(): Promise<Promise<Device>[]>;
     /**
      * get a list of all profiles
      * @returns {Promise<String>[]}


### PR DESCRIPTION
The typings don't match the implementation, as the implementation is async, but the typings say it returns an array. https://github.com/Mola19/openrgb-sdk/blob/bbd26e1833e86eb11fd49a273855da8954920823/src/client.js#L153-L159

The signature of this is pretty ugly here. Should it instead be changed to `getAllControllerData(): Promise<Device[]>;` with the implementation changing to `return Promise.all(devices)`?