### PR TITLE
Fix TypeScript declaration entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ all notable changes to this project will be documented in this file.
 the format is loosely based on [keep a changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### fixed
+
+- point package typings to the generated declaration entry point in dist
+
 ## [0.6.0] - 2025-07-25
 
 ### added

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@types/node": "^20.4.10",
 		"typescript": "^5.1.6"
 	},
-	"types": "./types/index.js",
+	"types": "./dist/index.d.ts",
 	"engines": {
 		"node": ">=8.3"
 	}


### PR DESCRIPTION
Hey there,

I was just playing around with your package in a project and noticed that it already had TypeScript declaration files, but they weren't exported correctly, so I thought I'd fix that for you ^^'

The `types` field in `package.json` pointed to the non-existing path `./types/index.js`, while the generated declaration files are actually published in `dist/`.

I updated the entrypoint to `./dist/index.d.ts` so TypeScript users can resolve the package typings correctly without any extra workarounds.

Verified locally with:

* `npm run build`
* `npm pack --dry-run`

Have a nice day/evening/night and stay productive ^^

- Kiba